### PR TITLE
add --gres=gpu:<num> to form.js + patch

### DIFF
--- a/form.js
+++ b/form.js
@@ -36,8 +36,16 @@ function convert_gpu_partitions(GRES) {
         for (const ind_gres of GRES) {
             const gpu_info = ind_gres.split(':');
             var number_of_gpus = Number(gpu_info[2].split("(")[0]);
+
             for (let i = 1; i <= number_of_gpus; i++) {
+                // putting this in its own loop so the options display in a better order
+                gpu_options.push([gpu_info[0], i].join(':'));
+            }
+
+            for (let i = 1; i <= number_of_gpus; i++) {
+                // original code puts gpu:h100:i or gpu:a100:i
                 gpu_options.push([gpu_info[0], gpu_info[1], i].join(':'));
+		            
             }
         }
         gpu_options.push('');

--- a/gpu_select_patch.patch
+++ b/gpu_select_patch.patch
@@ -1,0 +1,21 @@
+diff --git a/form.js b/form.js
+index 959d7b4..75392a3 100644
+--- a/form.js
++++ b/form.js
+@@ -36,8 +36,16 @@ function convert_gpu_partitions(GRES) {
+         for (const ind_gres of GRES) {
+             const gpu_info = ind_gres.split(':');
+             var number_of_gpus = Number(gpu_info[2].split("(")[0]);
++
++            for (let i = 1; i <= number_of_gpus; i++) {
++                // putting this in its own loop so the options display in a better order
++                gpu_options.push([gpu_info[0], i].join(':'));
++            }
++
+             for (let i = 1; i <= number_of_gpus; i++) {
++                // original code puts gpu:h100:i or gpu:a100:i
+                 gpu_options.push([gpu_info[0], gpu_info[1], i].join(':'));
++		            
+             }
+         }
+         gpu_options.push('');


### PR DESCRIPTION
Hi, Here is a PR to add the option(s) --gres=gpu:<num> in the job submission form dropdown for jupyter. The patch is in here too, but may not be needed for us to apply this to the other apps. Thanks! 