### PR TITLE
change name of formerly codex kernel

### DIFF
--- a/form.yml.erb
+++ b/form.yml.erb
@@ -47,7 +47,7 @@ attributes:
     options:
       - [ "ml-data-science-kernel-py311", "/software/rhel8/quest_ondemand/quest_ood_jupyter/rhel8-jupyter-new-ml-data-science.sif" ]
 #      - [ "ml-data-science-kernel-py310", "/software/openondemand/jupyter/jupyter-ood.sif" ]
-      - [ "CoDEx", "/software/rhel8/quest_ondemand/quest_ood_codex/workshop-040825.sif" ]
+      - [ "ollama-mlflow-py312", "/software/rhel8/quest_ondemand/quest_ood_codex/workshop-040825.sif" ]
       - [ "NicheCompass", "/software/rhel8/quest_ondemand/quest_ood_jupyter/niche-compass/nichecompass_jupyter.sif" ]
       - [ "PyVista", "/software/rhel8/quest_ondemand/quest_ood_jupyter/pyvista/pyvista.sif" ]
       - [ "openpi", "/software/2025/ondemand/jupyter/openpi_jupyter.sif" ]


### PR DESCRIPTION
I think the name of the actual kernel is misleading, or I misunderstood something? 

<img width="1186" height="456" alt="Screenshot 2025-09-30 at 10 29 18 AM" src="https://github.com/user-attachments/assets/6cc1e4f5-4a59-4d97-b6f2-3e295d211c43" />
